### PR TITLE
Fix typo airport_codes_flow.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To update the data run the process script locally:
 pip install dataflows
 
 # Run the script
-python airport_codes_flow.py
+python airport-codes-flow.py
 ```
 
 Several steps will be done to get the final data.


### PR DESCRIPTION
In the readme, there is typo for the airport_codes_flow.py file.
The file in the directory is airport-codes-flow.py.
Therefore, changed from airport_codes_flow.py to airport-codes-flow.py