### PR TITLE
Add frictionless validate to CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,10 @@ jobs:
             python-version: "3.12"
         - name: Run
           run: make
+        - name: Validate datapackage
+          run: |
+            pip install frictionless
+            frictionless validate datapackage.json
         - name: Commit and Push
           run: |
             git config --global user.name "GitHub Action"


### PR DESCRIPTION
## Change

Added a `Validate datapackage` step to `.github/workflows/actions.yml` that runs `frictionless validate datapackage.json` after `make` completes on every scheduled run and push.

This prevents descriptor/data drift from being silently committed: if a future script change produces columns or types that don't match `datapackage.json`, the workflow will fail before the commit step rather than silently pushing broken data.

```yaml
- name: Validate datapackage
  run: |
    pip install frictionless
    frictionless validate datapackage.json
```